### PR TITLE
Updated 'Usage Online' URL to include BTP latest icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Custom library for [Draw.io](https://app.diagrams.net/), based on [SAP Business 
 and/or an SAP affiliate company. The SAP Terms of Use found in document [Terms Of Use for the SAP Business Technology Platform Solution Diagrams, Design Elements & Icons](https://d.dam.sap.com/a/nXJJmw/SAP%20Cloud%20Platform%20Diagrams%20and%20Icons%20Terms%20of%20Use.pdf) govern your use of these SAP materials (as defined in the Terms of Use), and related Content and web pages.
 
 ## Usage online
-The easiest way to consume one of these libraries, is to load them directly via the url parameter ['libs'](https://desk.draw.io/support/solutions/articles/16000042546-supported-url-parameters). List the library urls as a semi-colon separated string. (example: https://app.diagrams.net/?splash=0&clibs=Uhttps://raw.githubusercontent.com/rsletta/sap_btp_icons_drawio_lib/main/libs/SAP_BTP_Service_Icons_Circles.xml;Uhttps://raw.githubusercontent.com/rsletta/sap_btp_icons_drawio_lib/main/libs/SAP_BTP_Service_Icons.xml)
+The easiest way to consume one of these libraries, is to load them directly via the url parameter ['libs'](https://desk.draw.io/support/solutions/articles/16000042546-supported-url-parameters). List the library urls as a semi-colon separated string. (example: https://app.diagrams.net/?splash=0&clibs=Uhttps://raw.githubusercontent.com/rsletta/sap_btp_icons_drawio_lib/main/libs/SAP_BTP_Service_Icons_Circles.xml;Uhttps://raw.githubusercontent.com/rsletta/sap_btp_icons_drawio_lib/main/libs/SAP_BTP_Service_Icons.xml;Uhttps://raw.githubusercontent.com/rsletta/sap_btp_icons_drawio_lib/main/libs/SAP_BTP_Service_Icons_latest.xml)
 
 ## The other way
 ### ### Select "Open Library/Github" from "File" menu


### PR DESCRIPTION
Fixing issue #3 by adding BTP latest icons into URL of 'Usage Online' section.